### PR TITLE
Initialize Sphinx for Documentation on Access Amherst

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -1,0 +1,24 @@
+name: "Sphinx: Render docs"
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build HTML
+      uses: ammaraskar/sphinx-action@master
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: html-docs
+        path: docs/build/html/
+    - name: Deploy
+      uses: peaceiris/actions-gh-pages@v3
+      if: github.ref == 'refs/heads/main'
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: docs/build/html

--- a/access_amherst_backend/docs/Makefile
+++ b/access_amherst_backend/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/access_amherst_backend/docs/README.md
+++ b/access_amherst_backend/docs/README.md
@@ -1,1 +1,2 @@
 # Access Amherst Documentation
+XXX

--- a/access_amherst_backend/docs/README.md
+++ b/access_amherst_backend/docs/README.md
@@ -1,0 +1,1 @@
+# Access Amherst Documentation

--- a/access_amherst_backend/docs/README.md
+++ b/access_amherst_backend/docs/README.md
@@ -1,2 +1,81 @@
-# Access Amherst Documentation
-XXX
+# Access Amherst Backend Documentation Guide
+
+This guide walks you through adding Documentation to Access Amherst with Sphinx.
+
+## Prerequisites
+
+Ensure you have the following installed in your project environment:
+
+- Sphinx
+- Django
+
+You can install Sphinx with:
+
+```bash
+pip install sphinx
+```
+
+## Adding Documentation for Models
+
+You can document your Django models (or other code) using Sphinx. Here’s an example using the `Event` model:
+
+```python
+# models.py
+from django.db import models
+
+class Event(models.Model):
+    id = models.IntegerField(primary_key=True, unique=True, null=False, blank=False)
+    title = models.CharField(max_length=255)
+    author_name = models.CharField(max_length=255, null=True, blank=True)
+    author_email = models.CharField(max_length=255, null=True, blank=True)
+    pub_date = models.DateTimeField()
+    host = models.TextField()
+    link = models.URLField(max_length=500)
+    picture_link = models.URLField(max_length=500, null=True, blank=True)
+    event_description = models.TextField(null=True, blank=True)
+    start_time = models.DateTimeField()
+    end_time = models.DateTimeField()
+    location = models.CharField(max_length=500)
+    categories = models.TextField()
+
+    def __str__(self):
+        return self.title
+```
+
+## Creating a `.rst` File for the Model
+
+1. **Create an ********`.rst`******** file** in `docs/source/` for the model, e.g., `event_model.rst`:
+
+   ```rst
+   Event Model
+   ============
+
+   .. automodule:: access_amherst_backend.models
+       :members: Event
+   ```
+
+2. **Update the ********`index.rst`******** file** to include the new `.rst` file:
+
+   ```rst
+   .. toctree::
+       :maxdepth: 2
+       :caption: Contents:
+
+       event_model
+   ```
+
+3. **Rebuild the HTML documentation** by running:
+
+   ```bash
+   make html
+   ```
+
+## Viewing the Documentation
+
+Each piece of documentation has it's own corresponding .html file that can be viewed:
+
+- **Locally**: Navigate to `build/html/index.html` in your file system and open it in a browser.
+- **In Gitpod**: Use the following command to preview it:
+  ```bash
+  gp preview $(pwd)/build/html/index.html
+  ```

--- a/access_amherst_backend/docs/make.bat
+++ b/access_amherst_backend/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/access_amherst_backend/docs/source/conf.py
+++ b/access_amherst_backend/docs/source/conf.py
@@ -1,0 +1,39 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'access_amherst_backend'
+copyright = '2024, Dhyey Mavani, Liam Davis, Ryan Ji, Shreya Hegde, Thu Hoang'
+author = 'Dhyey Mavani, Liam Davis, Ryan Ji, Shreya Hegde, Thu Hoang'
+release = '0.0.0'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    'sphinx.ext.autodoc',
+]
+
+templates_path = ['_templates']
+exclude_patterns = []
+
+language = 'python'
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'alabaster'
+html_static_path = ['_static']
+
+# set up Django environment
+import os
+import sys
+import django
+
+sys.path.insert(0, os.path.abspath('../..'))
+os.environ['DJANGO_SETTINGS_MODULE'] = 'access_amherst_backend.settings'
+django.setup()

--- a/access_amherst_backend/docs/source/event_model.rst
+++ b/access_amherst_backend/docs/source/event_model.rst
@@ -1,0 +1,5 @@
+Event Model
+============
+
+.. automodule:: access_amherst_algo.models
+    :members: Event

--- a/access_amherst_backend/docs/source/index.rst
+++ b/access_amherst_backend/docs/source/index.rst
@@ -1,0 +1,19 @@
+.. access_amherst_backend documentation master file, created by
+   sphinx-quickstart on Tue Oct 29 20:08:27 2024.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+access_amherst_backend documentation
+====================================
+
+Add your content using ``reStructuredText`` syntax. See the
+`reStructuredText <https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html>`_
+documentation for details.
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   event_model
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ click-plugins==1.1.1
 click-repl==0.3.0
 Django==5.1.1
 docstring_parser==0.16
+furo
 gcloud==0.18.3
 google-ai-generativelanguage==0.6.10
 google-api-core==2.21.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+alabaster==1.0.0
 amqp==5.2.0
 annotated-types==0.7.0
 asgiref==3.8.1
@@ -29,6 +30,7 @@ grpc-google-iam-v1==0.13.1
 grpcio==1.67.0
 grpcio-status==1.67.0
 httplib2==0.22.0
+imagesize==1.4.1
 imaplib2==3.6
 kombu==5.4.2
 numpy==2.1.2
@@ -46,6 +48,13 @@ pytz==2024.2
 redis==5.2.0
 rsa==4.9
 shapely==2.0.6
+Sphinx==8.1.3
+sphinxcontrib-applehelp==2.0.0
+sphinxcontrib-devhelp==2.0.0
+sphinxcontrib-htmlhelp==2.1.0
+sphinxcontrib-jsmath==1.0.1
+sphinxcontrib-qthelp==2.0.0
+sphinxcontrib-serializinghtml==2.0.0
 sqlparse==0.5.1
 tqdm==4.66.5
 tzdata==2024.2


### PR DESCRIPTION
I initialized sphinx for documentation in the access_amherst_backend/docs directory. Refer to the README there for instructions on how to add and view documentation.