### PR TITLE
Updated Settings for Proper Celery Config

### DIFF
--- a/access_amherst_backend/access_amherst_backend/settings.py
+++ b/access_amherst_backend/access_amherst_backend/settings.py
@@ -129,13 +129,26 @@ STATIC_URL = "static/"
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
-# Celery tasks
-CELERY_BEAT_SCHEDULE = {
-    "delete-old-events-every-24-hours": {
-        "task": "access_amherst_algo.tasks.remove_old_events",
-        "schedule": 86400.0,  # 86400 seconds = 24 hours
-    },
+# Celery Configuration
+CELERY_TIMEZONE = "America/New_York"  # Match the timezone you're using in celery.py
+CELERY_TASK_TRACK_STARTED = True
+CELERY_TASK_TIME_LIMIT = 30 * 60  # 30 minutes
+CELERY_BEAT_SCHEDULER = 'django_celery_beat.schedulers:DatabaseScheduler'
+
+# Redis Configuration (for production)
+CELERY_BROKER_URL = os.getenv('REDIS_URL', 'redis://localhost:6379/0')
+CELERY_RESULT_BACKEND = os.getenv('REDIS_URL', 'redis://localhost:6379/0')
+
+# Production settings for reliability
+CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True
+CELERY_BROKER_CONNECTION_MAX_RETRIES = None
+CELERY_BROKER_TRANSPORT_OPTIONS = {
+    'visibility_timeout': 21600,  # 6 hours (matching your longest interval)
+    'max_connections': 20,
+    'socket_timeout': 30,
+    'socket_connect_timeout': 30,
 }
 
-# Redis Server
-CELERY_BROKER_URL = "redis://localhost:6379/0"
+# Time zone settings (should match Celery's timezone)
+TIME_ZONE = "America/New_York"
+USE_TZ = True


### PR DESCRIPTION
This pull request includes significant changes to the Celery and Redis configurations in the `access_amherst_backend/settings.py` file. The modifications enhance the reliability and performance of the Celery tasks by updating the Celery settings and integrating Redis for production use.

### Celery Configuration Updates:

* Added Celery timezone setting to match the timezone used in `celery.py`.
* Enabled task tracking and set a task time limit of 30 minutes.
* Configured Celery to use `DatabaseScheduler` for beat scheduling.

### Redis Configuration for Production:

* Set the Celery broker and result backend URLs to use Redis, with fallback to localhost.
* Enabled broker connection retry on startup and set transport options for reliability, including visibility timeout, max connections, and socket timeouts.

### Time Zone Settings:

* Updated the time zone settings to match Celery's timezone, ensuring consistency across the application.