### PR TITLE
Added Google Analytics Tags to HTML Forms

### DIFF
--- a/access_amherst_backend/access_amherst_algo/templates/access_amherst_algo/calendar.html
+++ b/access_amherst_backend/access_amherst_algo/templates/access_amherst_algo/calendar.html
@@ -2,6 +2,17 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-L00WJ9XVMH"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', 'G-L00WJ9XVMH');
+    </script>
+    
+
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Weekly Calendar View</title>

--- a/access_amherst_backend/access_amherst_algo/templates/access_amherst_algo/dashboard.html
+++ b/access_amherst_backend/access_amherst_algo/templates/access_amherst_algo/dashboard.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-L00WJ9XVMH"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', 'G-L00WJ9XVMH');
+    </script>
+    
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Access Amherst - Dashboard</title>

--- a/access_amherst_backend/access_amherst_algo/templates/access_amherst_algo/home.html
+++ b/access_amherst_backend/access_amherst_algo/templates/access_amherst_algo/home.html
@@ -2,6 +2,16 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-L00WJ9XVMH"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', 'G-L00WJ9XVMH');
+    </script>
+
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Access Amherst</title>

--- a/access_amherst_backend/access_amherst_algo/templates/access_amherst_algo/map.html
+++ b/access_amherst_backend/access_amherst_algo/templates/access_amherst_algo/map.html
@@ -1,6 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-L00WJ9XVMH"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', 'G-L00WJ9XVMH');
+    </script>
+    
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Access Amherst - Event Map</title>


### PR DESCRIPTION
This pull request includes the addition of Google Analytics tracking code to multiple HTML templates in the `access_amherst_backend/access_amherst_algo/templates/access_amherst_algo` directory. The most important changes are listed below:

* [`calendar.html`](diffhunk://#diff-b1ecf565316f417fff50530c37c061857e30eb5fec83365d37597ea830e88d44R5-R15): Added Google Analytics tracking code to enable tracking of user interactions on the weekly calendar view.
* [`dashboard.html`](diffhunk://#diff-34d7d8872d34b70e1a90c77c74a587849aa198efaee69c5de21d01ba6c30ceb6R4-R13): Added Google Analytics tracking code to enable tracking of user interactions on the dashboard.
* [`home.html`](diffhunk://#diff-d48ca7d8c914463ea803baebe704488f89f03fe5acf177f34419b8bc534c2036R5-R14): Added Google Analytics tracking code to enable tracking of user interactions on the home page.
* [`map.html`](diffhunk://#diff-3ea503d1bb1d6dfad4fc409cbe2757b6bc03ca7ff50cbc6412f2eb920737c54aR4-R13): Added Google Analytics tracking code to enable tracking of user interactions on the event map.