### PR TITLE
Rewrote Search Algo to use Cosine Similarity

### DIFF
--- a/access_amherst_backend/access_amherst_algo/views.py
+++ b/access_amherst_backend/access_amherst_algo/views.py
@@ -61,7 +61,7 @@ def home(request):
         start_date=start_time.date(),
         end_date=end_time.date(),
     )
-    events = filter_events_by_category(events, categories).order_by("start_time")
+    events = filter_events_by_category(events, categories)
 
     return render(
         request,


### PR DESCRIPTION
Addresses #75 

This pull request introduces changes to the `filter_events` function in `parse_database.py` to enhance event filtering by incorporating cosine similarity for event titles. Additionally, it updates the corresponding tests to verify the new functionality.

Enhancements to event filtering:

* [`access_amherst_backend/access_amherst_algo/parse_database.py`](diffhunk://#diff-f3ce7d9af81a8270545cd8f3a2c17437971bd17fc1132c492466cfb189adbafcR7-R12): Added `similarity_threshold` parameter to `filter_events` function and implemented cosine similarity filtering for event titles using `TfidfVectorizer` and `cosine_similarity` from `sklearn`. Introduced helper functions `preprocess_text` and `compute_similarity_scores` to support the new filtering mechanism. [[1]](diffhunk://#diff-f3ce7d9af81a8270545cd8f3a2c17437971bd17fc1132c492466cfb189adbafcR7-R12) [[2]](diffhunk://#diff-f3ce7d9af81a8270545cd8f3a2c17437971bd17fc1132c492466cfb189adbafcR33-R34) [[3]](diffhunk://#diff-f3ce7d9af81a8270545cd8f3a2c17437971bd17fc1132c492466cfb189adbafcL45-R136)

Updates to tests:

* [`access_amherst_backend/access_amherst_tests/test_parse_database.py`](diffhunk://#diff-a64f3a2d920975e051cc8f798818c2a5af0fc5be43cc3590fd4c1a6f38e92d28L77-R113): Expanded `test_filter_events` to include tests for the new similarity-based filtering and ordering by similarity and start time.

Minor fix:

* [`access_amherst_backend/access_amherst_algo/views.py`](diffhunk://#diff-1546036abfc3e7357fe70af96a2e17af24f9ad1ea4ae1f784234f0c21f3f719aL64-R64): Removed the redundant `order_by("start_time")` call in `home` function after filtering events by category.