### PR TITLE
Refactor site title to be a clickable link across all main templates

### DIFF
--- a/access_amherst_backend/access_amherst_algo/templates/access_amherst_algo/calendar.html
+++ b/access_amherst_backend/access_amherst_algo/templates/access_amherst_algo/calendar.html
@@ -8,6 +8,16 @@
     <title>Amherst Connect - Calendar</title>
     <link rel="stylesheet" href="{% static 'access_amherst_algo/css/styles.css' %}">
     <style>
+        .site-title {
+            text-decoration: none;
+            color: inherit;
+            cursor: pointer;
+        }
+
+        .site-title:hover {
+            opacity: 0.9;
+        }
+
         /* Grid Layout */
         .calendar-container {
             margin: calc(var(--header-height) + 10px) auto 0;
@@ -233,7 +243,7 @@
 <body>
     <!-- Navigation buttons -->
     <header class="main-header">
-        <div class="site-title">Amherst Connect</div>
+        <a href="{% url 'home' %}" class="site-title">Amherst Connect</a>
         <nav class="nav-buttons">
             <a href="{% url 'home' %}" class="nav-button">Events</a>
             <a href="{% url 'map' %}" class="nav-button">Map</a>

--- a/access_amherst_backend/access_amherst_algo/templates/access_amherst_algo/dashboard.html
+++ b/access_amherst_backend/access_amherst_algo/templates/access_amherst_algo/dashboard.html
@@ -9,6 +9,16 @@
     <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@2.0.0/dist/chartjs-adapter-date-fns.bundle.min.js"></script>
     <link rel="stylesheet" href="{% static 'access_amherst_algo/css/styles.css' %}">
     <style>
+        .site-title {
+            text-decoration: none;
+            color: inherit;
+            cursor: pointer;
+        }
+
+        .site-title:hover {
+            opacity: 0.9;
+        }
+
         /* Dashboard-specific styles only */
         .dashboard-grid {
             display: grid;
@@ -209,7 +219,7 @@
 </head>
 <body>
     <header class="main-header">
-        <div class="site-title">Amherst Connect</div>
+        <a href="{% url 'home' %}" class="site-title">Amherst Connect</a>
         <nav class="nav-buttons">
             <a href="{% url 'map' %}" class="nav-button">Map</a>
             <a href="{% url 'home' %}" class="nav-button">Events</a>

--- a/access_amherst_backend/access_amherst_algo/templates/access_amherst_algo/home.html
+++ b/access_amherst_backend/access_amherst_algo/templates/access_amherst_algo/home.html
@@ -8,6 +8,16 @@
     <link href="https://cdn.jsdelivr.net/npm/slim-select@2.8.1/dist/slimselect.css" rel="stylesheet" />
     <link rel="stylesheet" href="{% static 'access_amherst_algo/css/styles.css' %}">
     <style>
+        .site-title {
+            text-decoration: none;
+            color: inherit;
+            cursor: pointer;
+        }
+
+        .site-title:hover {
+            opacity: 0.9;
+        }
+
         /* Add to styles.css */
         .filter-container {
             display: grid;
@@ -119,7 +129,7 @@
 <body>
     <!-- Fixed Header -->
     <header class="main-header">
-        <div class="site-title">Amherst Connect</div>
+        <a href="{% url 'home' %}" class="site-title">Amherst Connect</a>
         <nav class="nav-buttons">
             <a href="{% url 'map' %}" class="nav-button">Map</a>
             <a href="{% url 'dashboard' %}" class="nav-button">Dashboard</a>

--- a/access_amherst_backend/access_amherst_algo/templates/access_amherst_algo/map.html
+++ b/access_amherst_backend/access_amherst_algo/templates/access_amherst_algo/map.html
@@ -7,6 +7,16 @@
     <title>Amherst Connect - Map</title>
     <link rel="stylesheet" href="{% static 'access_amherst_algo/css/styles.css' %}">
     <style>
+        .site-title {
+            text-decoration: none;
+            color: inherit;
+            cursor: pointer;
+        }
+
+        .site-title:hover {
+            opacity: 0.9;
+        }
+
         /* Keep only map-specific styles */
         #map {
             flex: 1;
@@ -28,7 +38,7 @@
 </head>
 <body>
     <header class="main-header">
-        <div class="site-title">Amherst Connect</div>
+        <a href="{% url 'home' %}" class="site-title">Amherst Connect</a>
         <nav class="nav-buttons">
             <a href="{% url 'home' %}" class="nav-button">Events</a>
             <a href="{% url 'dashboard' %}" class="nav-button">Dashboard</a>


### PR DESCRIPTION
This pull request includes changes to improve the user interface and navigation experience across multiple HTML templates in the `access_amherst_algo` project. The most important changes include adding a hover effect to the site title and converting the site title from a `div` to a clickable link that redirects to the home page.

User Interface Improvements:

* Added hover effect to the `.site-title` class to change opacity when hovered. (`access_amherst_backend/access_amherst_algo/templates/access_amherst_algo/calendar.html`, `access_amherst_backend/access_amherst_algo/templates/access_amherst_algo/dashboard.html`, `access_amherst_backend/access_amherst_algo/templates/access_amherst_algo/home.html`, `access_amherst_backend/access_amherst_algo/templates/access_amherst_algo/map.html`) [[1]](diffhunk://#diff-b1ecf565316f417fff50530c37c061857e30eb5fec83365d37597ea830e88d44R11-R20) [[2]](diffhunk://#diff-34d7d8872d34b70e1a90c77c74a587849aa198efaee69c5de21d01ba6c30ceb6R12-R21) [[3]](diffhunk://#diff-d48ca7d8c914463ea803baebe704488f89f03fe5acf177f34419b8bc534c2036R11-R20) [[4]](diffhunk://#diff-3ea503d1bb1d6dfad4fc409cbe2757b6bc03ca7ff50cbc6412f2eb920737c54aR10-R19)

Navigation Improvements:

* Changed the `div` element with the `site-title` class to an `a` element that links to the home page. (`access_amherst_backend/access_amherst_algo/templates/access_amherst_algo/calendar.html`, `access_amherst_backend/access_amherst_algo/templates/access_amherst_algo/dashboard.html`, `access_amherst_backend/access_amherst_algo/templates/access_amherst_algo/home.html`, `access_amherst_backend/access_amherst_algo/templates/access_amherst_algo/map.html`) [[1]](diffhunk://#diff-b1ecf565316f417fff50530c37c061857e30eb5fec83365d37597ea830e88d44L236-R246) [[2]](diffhunk://#diff-34d7d8872d34b70e1a90c77c74a587849aa198efaee69c5de21d01ba6c30ceb6L212-R222) [[3]](diffhunk://#diff-d48ca7d8c914463ea803baebe704488f89f03fe5acf177f34419b8bc534c2036L122-R132) [[4]](diffhunk://#diff-3ea503d1bb1d6dfad4fc409cbe2757b6bc03ca7ff50cbc6412f2eb920737c54aL31-R41)