### PR TITLE
Changed background color to light gray + enhanced box shadow for home page and dashboard

### DIFF
--- a/access_amherst_backend/access_amherst_algo/static/access_amherst_algo/css/styles.css
+++ b/access_amherst_backend/access_amherst_algo/static/access_amherst_algo/css/styles.css
@@ -1,7 +1,7 @@
 /* styles.css */
 :root {
     --primary-color: #3f1f69;
-    --background-color: #f3e5f5;
+    --background-color: #f2f2f2;
     --header-height: 60px;
     --border-color: #ddd;
     --event-text: #fff;

--- a/access_amherst_backend/access_amherst_algo/templates/access_amherst_algo/dashboard.html
+++ b/access_amherst_backend/access_amherst_algo/templates/access_amherst_algo/dashboard.html
@@ -41,7 +41,7 @@
             background: white;
             border-radius: 8px;
             padding: 20px;
-            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            box-shadow: 0 2px 4px rgba(0,0,0,0.25);
             height: auto;
         }
     

--- a/access_amherst_backend/access_amherst_algo/templates/access_amherst_algo/home.html
+++ b/access_amherst_backend/access_amherst_algo/templates/access_amherst_algo/home.html
@@ -86,6 +86,7 @@
         .event-item {
             position: relative;
             overflow: hidden;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.25);
         }
 
         .event-emojis {

--- a/access_amherst_backend/staticfiles/access_amherst_algo/css/styles.css
+++ b/access_amherst_backend/staticfiles/access_amherst_algo/css/styles.css
@@ -1,7 +1,7 @@
 /* styles.css */
 :root {
     --primary-color: #3f1f69;
-    --background-color: #f3e5f5;
+    --background-color: #f2f2f2;
     --header-height: 60px;
     --border-color: #ddd;
     --event-text: #fff;


### PR DESCRIPTION
This pull request includes several changes to the styling of the `access_amherst_algo` project, focusing on adjustments to colors and shadows in the CSS and HTML files. The most important changes include updating the background color and modifying the box-shadow properties for better visual consistency.

Color adjustments:
* [`access_amherst_backend/access_amherst_algo/static/access_amherst_algo/css/styles.css`](diffhunk://#diff-f99abff0b9d79e0867eaaeec983ff89b0d79c2a04cbb6c0da4c683dd76b1c421L4-R4): Changed the `--background-color` from `#f3e5f5` to `#f2f2f2` for a more neutral background.
* [`access_amherst_backend/staticfiles/access_amherst_algo/css/styles.css`](diffhunk://#diff-f99abff0b9d79e0867eaaeec983ff89b0d79c2a04cbb6c0da4c683dd76b1c421L4-R4): Updated the `--background-color` to `#f2f2f2` to match the primary styles file.

Shadow adjustments:
* [`access_amherst_backend/access_amherst_algo/templates/access_amherst_algo/dashboard.html`](diffhunk://#diff-34d7d8872d34b70e1a90c77c74a587849aa198efaee69c5de21d01ba6c30ceb6L44-R44): Increased the opacity of the `box-shadow` from `0.1` to `0.25` for a more pronounced shadow effect.
* [`access_amherst_backend/access_amherst_algo/templates/access_amherst_algo/home.html`](diffhunk://#diff-d48ca7d8c914463ea803baebe704488f89f03fe5acf177f34419b8bc534c2036R89): Added a `box-shadow` property with `rgba(0,0,0,0.25)` to the `.event-item` class for visual consistency.