### PR TITLE
Add Individual Contributions Details and Improve About Page Style

### DIFF
--- a/access_amherst_backend/access_amherst_algo/templates/access_amherst_algo/about.html
+++ b/access_amherst_backend/access_amherst_algo/templates/access_amherst_algo/about.html
@@ -47,6 +47,28 @@
             text-align: center;
         }
 
+        #contributions {
+            text-align: center;
+            margin: 20px 0;
+        }
+        
+        #contributions a {
+            color: var(--primary-color);
+            text-decoration: underline;
+            padding: 5px 10px;
+            border-radius: 4px;
+            background-color: rgba(var(--primary-color-rgb), 0.1);
+            border: 1px solid var(--primary-color);
+            transition: all 0.2s ease;
+        }
+        
+        #contributions a:hover {
+            background-color: var(--primary-color);
+            color: white;
+            text-decoration: none;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+
         .team-img {
             display: block;
             margin: 0 auto 20px auto;
@@ -141,6 +163,7 @@
 
         <section id="about-team">
             <h2>Engineering Team</h2>
+            <h3 id="contributions"><a href="https://github.com/ac-i2i-engineering/access-amherst/graphs/contributors">See Our Individual Contributions</a></h3>
 
             <div id="team-cards">
                 <div class="team-card">
@@ -173,9 +196,10 @@
             <div id="founder-card">
                 <div id="founder-profile">
                     <img class="team-img founder-img" src="{% static 'shreyahegde26.jpg' %}" alt="Engineering Team Lead">
-                    <p class="team-name">Shreya Hegde '26 Engineer</p>
+                    <p class="team-name">Shreya Hegde '26</p>
+                    <p class="team-role">Engineer</p>
                 </div>
-                <p>"When I noticed that Amherst could sometimes feel isolating and that students struggled to stay informed about campus events, I felt motivated to help. I came up with the idea to create a website with an events map and calendar to bring students closer to campus life. I requested senate funding as a senator, collaborated with an engineering team, contributed to the coding and design, and contacted IT, SEL, and the communications offices to discuss future plans. Our team created something to make it easier for everyone to stay connected."
+                <p>"When I noticed that Amherst could sometimes feel isolating and that students struggled to stay informed about campus events, I felt motivated to help. I came up with the idea to create a website with an events map and calendar to bring students closer to campus life. I requested senate funding as a senator, worked with i2i's engineering team to build the product, and contacted IT, SEL, and the communications offices to discuss future plans. Our team created something to make it easier for everyone to stay connected."
                 </p>
             </div>
             <br>


### PR DESCRIPTION
This pull request includes updates to the `about.html` file in the `access_amherst_algo` template. The changes focus on improving the layout and content presentation of the "About Us" page.

Layout and styling improvements:

* Added a new section with the ID `contributions` to center-align text and style links with a primary color, underline, padding, border, and hover effects.

Content updates:

* Added a new subheading with a link to the GitHub contributors page under the "Engineering Team" section.
* Updated the founder's profile to separate the name and role into different paragraphs and revised the description text to reflect the collaboration with i2i's engineering team.